### PR TITLE
Review travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,9 @@ matrix:
 
 
 script:
+  - make
   - sudo make install
-  - PGPORT=5432 make installcheck
-
-
-after_failure:
-  - cat /home/travis/build/linz/postgresql-tableversion/regression.out
+  - PGPORT=5432 make installcheck || cat regression.diffs
 
 
 notifications:


### PR DESCRIPTION
Print regressions diff instead of output, on failure.
Use a separate `make` step