### PR TITLE
Improves the performance of the ver_get_table_differences function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ in this file.
 - `ver_version` function
 ### Changed
 - Upgrade scripts are now generated (#35)
+- Performance of `ver_get_table_differences` improved (#15)
 
 
 ## [1.2.0] - 2016-09-13

--- a/sql/15-table_diff_functions.sql
+++ b/sql/15-table_diff_functions.sql
@@ -119,7 +119,8 @@ BEGIN
         ARRAY[
             quote_ident(p_compare_key),
             @extschema@._ver_get_compare_sql(v_unique_cols,'T'),
-            (SELECT array_to_string(array_agg(att_name), ',') att_name FROM unnest(v_common_cols)),
+            (SELECT array_to_string(array_agg(quote_ident(att_name)), ',')
+              att_name FROM unnest(v_common_cols)),
             p_table1::TEXT,
             p_table2::TEXT
         ]

--- a/sql/15-table_diff_functions.sql
+++ b/sql/15-table_diff_functions.sql
@@ -95,7 +95,7 @@ BEGIN
 		    CAST('D' AS CHAR(1))
 	    WHEN t1.%1% IS NULL THEN
 		    CAST('I' AS CHAR(1))
-	    WHEN CAST(%2% AS TEXT) <> CAST(%2% AS TEXT) THEN
+	    WHEN CAST(%2% AS TEXT) <> CAST(%3% AS TEXT) THEN
 		    CAST('X' AS CHAR(1))
 	    ELSE
 		    CAST('U' AS CHAR(1))
@@ -106,19 +106,20 @@ BEGIN
 		    t2.%1%
 	    END AS id
 	FROM
-	    (SELECT %3% FROM %4%) AS t1
+	    (SELECT %4% FROM %5%) AS t1
 	    FULL OUTER JOIN
-	    (SELECT %3% FROM %5%) AS t2
+	    (SELECT %4% FROM %6%) AS t2
 	    ON t2.%1% = t1.%1%
 	WHERE
 	    t1.%1% IS NULL OR
 	    t2.%1% IS NULL OR
-	    CAST(%2% AS TEXT) <> CAST(%2% AS TEXT) OR
+	    CAST(%2% AS TEXT) <> CAST(%3% AS TEXT) OR
 	    NOT COALESCE(t1.* = t2.*, FALSE)
         $sql$,
         ARRAY[
             quote_ident(p_compare_key),
-            @extschema@._ver_get_compare_sql(v_unique_cols,'T'),
+            @extschema@._ver_get_compare_sql(v_unique_cols,'t1'),
+            @extschema@._ver_get_compare_sql(v_unique_cols,'t2'),
             (SELECT array_to_string(array_agg(quote_ident(att_name)), ',')
               att_name FROM unnest(v_common_cols)),
             p_table1::TEXT,


### PR DESCRIPTION
Fix for #15

Removes the current PL/PgSQL cursor loop implementation and replaces
it with a single SQL statement using FULL OUTER JOIN to determine
rows which are not in each tables. The PostGIS geometry datatype is
specially supported using EWKB comparison (NOTE: = operator only
does a BBOX comparison for PostGIS geometry datatype)