### PR TITLE
Report failure when `installcheck` fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ before_install:
 script:
   - make
   - sudo make install
-  - PGPORT=5432 make installcheck || cat regression.diffs
+  - PGPORT=5432 make installcheck || { cat regression.diffs; false; }
   # debian packaging is only available for PostgreSQL 9.3,
   # see https://github.com/linz/postgresql-tableversion/issues/27
   #


### PR DESCRIPTION
Otherwise it currently always succeeds due to the "or" branch 
running a successful command (cat).

See
https://travis-ci.org/linz/postgresql-tableversion/jobs/259306387#L610