### PR TITLE
Put debian/control back in the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ test/sql/preparedb
 
 # Debian Packaging
 ##################
-debian/control
 debian/postgresql*-tableversion/
 debian/postgresql*tableversion.substvars
 debian/postgresql*tableversion.debhelper

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,9 @@ script:
   - PGPORT=5432 make installcheck || { cat regression.diffs; false; }
   # Test upgrades from all tagged versions
   - PGPORT=5432 test/ci/test_all_upgrades.sh
-  - make deb
-  # Test install from package
+  # Test build and install from package.
+  - PG_SUPPORTED_VERSIONS=${POSTGRESQL} make deb
   - sudo env "PATH=$PATH" dpkg -i ../postgresql-${POSTGRESQL}-tableversion_*.deb
-
 
 notifications:
   # LINZ corporate email server is dropping messages from Travis

--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ Building Debian packaging
 
 Build the Debian packages using the following command:
 
-    dpkg-buildpackage -us -uc -b
+    make deb
+
+The number of packages built will depend on the number of supported
+PostgreSQL versions on your system. Make sure to install the
+postgresql-server-dev-all package, and consider adding the
+postgresql.org apt repository to get the most versions out
+of it (see https://wiki.postgresql.org/wiki/Apt)
 
 Installing the extension
 ------------------------

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,22 @@
+Source: postgresql-tableversion
+Section: database
+Priority: extra
+Build-Depends: debhelper (>= 7),
+               postgresql-server-dev-all
+Standards-Version: 3.9.5
+Maintainer: Ivan Mincik <imincik@linz.govt.nz>
+Homepage: http://www.linz.govt.nz
+Vcs-Git: git://github.com/linz/postgresql-tableversion.git
+Vcs-Browser: https://github.com/linz/postgresql-tableversion
+
+Package: postgresql-9.3-tableversion
+Architecture: all
+Depends: ${misc:Depends},
+         postgresql-9.3
+Recommends:
+Description: PostgreSQL table versioning extension, recording row modifications
+ and its history. The extension provides APIs for accessing snapshots of a table
+ at certain revisions and the difference generated between any two given
+ revisions. The extension uses a PL/PgSQL trigger based system to record and
+ provide access to the row revisions
+


### PR DESCRIPTION
It was reported by @imincik that having the file in the repository
greatly simplifies package building.

I still look forward to drop it, but it's to be postponed :)

Let's see if Travis is still happy with this (#49)