### PR TITLE
Have ver_is_table_versioned return false when triggers are lost

### DIFF
--- a/sql/08-is_table_versioned.sql
+++ b/sql/08-is_table_versioned.sql
@@ -53,7 +53,7 @@ BEGIN
     IF NOT v_is_versioned THEN
         RAISE WARNING 'Table %.% is known as versioned but lacks versioning triggers',
           p_schema, p_table
-        USING HINT = 'use ver_create_version_trigger to recover';
+        USING HINT = 'use ver_enable_versioniong to recover';
     END IF;
 
     RETURN v_is_versioned;

--- a/sql/08-is_table_versioned.sql
+++ b/sql/08-is_table_versioned.sql
@@ -25,19 +25,10 @@ RETURNS BOOLEAN AS
 $$
 DECLARE
     v_is_versioned BOOLEAN;
-    v_has_trigger BOOLEAN;
 BEGIN
-    SELECT
-        versioned
-    INTO
-        v_is_versioned
-    FROM
-        @extschema@.versioned_tables
-    WHERE
-        schema_name = p_schema AND
-        table_name = p_table;
+    v_is_versioned := @extschema@._ver_is_table_versioned(p_schema, p_table);
 
-    IF v_is_versioned IS NULL THEN
+    IF v_is_versioned IS FALSE THEN
         RETURN FALSE;
     END IF;
 

--- a/sql/08-is_table_versioned.sql
+++ b/sql/08-is_table_versioned.sql
@@ -1,28 +1,72 @@
 
+CREATE OR REPLACE FUNCTION _ver_is_table_versioned(
+    p_schema NAME,
+    p_table  NAME
+)
+RETURNS BOOLEAN AS
+$$
+    SELECT EXISTS (
+      SELECT
+          versioned
+      FROM
+          @extschema@.versioned_tables
+      WHERE
+          schema_name = p_schema AND
+          table_name = p_table
+    )
+$$ LANGUAGE sql STABLE;
+
+-- {
 CREATE OR REPLACE FUNCTION ver_is_table_versioned(
     p_schema NAME,
     p_table  NAME
 )
-RETURNS BOOLEAN AS 
+RETURNS BOOLEAN AS
 $$
 DECLARE
     v_is_versioned BOOLEAN;
+    v_has_trigger BOOLEAN;
 BEGIN
     SELECT
         versioned
     INTO
         v_is_versioned
-    FROM 
-        @extschema@.versioned_tables 
+    FROM
+        @extschema@.versioned_tables
     WHERE
         schema_name = p_schema AND
         table_name = p_table;
 
     IF v_is_versioned IS NULL THEN
-        v_is_versioned := FALSE;
+        RETURN FALSE;
+    END IF;
+
+    -- Check that table exists and triggers are in place;
+    -- warn otherwise, see:
+    -- https://github.com/linz/postgresql-tableversion/issues/57
+    BEGIN
+      v_is_versioned := EXISTS (
+        SELECT *
+      FROM pg_trigger t
+      WHERE t.tgrelid = (quote_ident(p_schema) || '.' || quote_ident(p_table) )::regclass
+        AND t.tgname = p_schema || '_' || p_table || '_revision_trg'
+      );
+    EXCEPTION
+      WHEN UNDEFINED_TABLE THEN
+        RAISE WARNING 'Table %.% does not exist', p_schema, p_table;
+        RETURN FALSE;
+      WHEN OTHERS THEN
+        RAISE EXCEPTION 'Got % (%)', SQLERRM, SQLSTATE;
+    END;
+
+    IF NOT v_is_versioned THEN
+        RAISE WARNING 'Table %.% is known as versioned but lacks versioning triggers',
+          p_schema, p_table
+        USING HINT = 'use ver_create_version_trigger to recover';
     END IF;
 
     RETURN v_is_versioned;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;
+-- }
 

--- a/sql/11-get_versioned_tables.sql
+++ b/sql/11-get_versioned_tables.sql
@@ -12,7 +12,8 @@ RETURNS TABLE(
     FROM 
         @extschema@.versioned_tables
     WHERE
-        versioned = TRUE;
+        versioned = TRUE AND
+        @extschema@.ver_is_table_versioned(schema_name, table_name);
 $$ LANGUAGE sql;
 
 /**
@@ -33,7 +34,8 @@ AS $$
     WHERE
         versioned = TRUE AND
         schema_name = $1 AND
-        table_name = $2;
+        table_name = $2 AND
+        @extschema@.ver_is_table_versioned(schema_name, table_name);
 $$ LANGUAGE sql;
 
 

--- a/sql/12-create_table_functions.sql
+++ b/sql/12-create_table_functions.sql
@@ -25,7 +25,7 @@ DECLARE
     v_select_columns_diff TEXT;
     v_select_columns_rev  TEXT;
 BEGIN
-    IF NOT @extschema@.ver_is_table_versioned(p_schema, p_table) THEN
+    IF NOT @extschema@._ver_is_table_versioned(p_schema, p_table) THEN
         RAISE EXCEPTION 'Table %.% is not versioned', quote_ident(p_schema), quote_ident(p_table);
     END IF;
     

--- a/sql/13-create_version_trigger.sql
+++ b/sql/13-create_version_trigger.sql
@@ -21,7 +21,7 @@ DECLARE
     v_column_name    NAME;
     v_column_update  TEXT;
 BEGIN
-    IF NOT @extschema@.ver_is_table_versioned(p_schema, p_table) THEN
+    IF NOT @extschema@._ver_is_table_versioned(p_schema, p_table) THEN
         RAISE EXCEPTION 'Table %.% is not versioned', quote_ident(p_schema), quote_ident(p_table);
     END IF;
     

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..84
+1..85
 ok 1 - Schema table_version should exist
 ok 2 - Should have revision table
 ok 3 - Should have tables_changed table
@@ -83,6 +83,7 @@ WARNING:  Table foo.dropme does not exist
 ok 80 - foo.dropme is not versioned after drop cascade
 WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
 ok 81 - foo.dropme is not versioned after re-create
-ok 82 - can create version trigger on foo.dropme
-ok 83 - foo.dropme is not versioned after re-create and create_version_trigger
-ok 84 - Function table_version.ver_version() should exist
+ok 82 - can enable versioning on drop-recreated table foo.dropme
+ok 83 - foo.dropme is not versioned after re-create and ver_enable_versioning
+ok 84 - ver_enable_versioning throws when called on already-versioned table
+ok 85 - Function table_version.ver_version() should exist

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,18 +1,5 @@
---------------------------------------------------------------------------------
--- postgresql-table_version - PostgreSQL table versioning extension
---
--- Copyright 2016 Crown copyright (c)
--- Land Information New Zealand and the New Zealand Government.
--- All rights reserved
---
--- This software is released under the terms of the new BSD license. See the 
--- LICENSE file for more information.
---
---------------------------------------------------------------------------------
--- Provide unit testing for table versioning system using pgTAP
---------------------------------------------------------------------------------
 \set ECHO none
-1..77
+1..84
 ok 1 - Schema table_version should exist
 ok 2 - Should have revision table
 ok 3 - Should have tables_changed table
@@ -89,4 +76,13 @@ ok 73 - Test foo_bar5_revision permission for test_user
 ok 74 - Disable versioning on foo.bar5
 ok 75 - Diff function between fOo.Bar3 and foO.bAr4
 ok 76 - Diff function between fOo.Bar3 and foO.bAr4 (with unique column)
-ok 77 - Function table_version.ver_version() should exist
+ok 77 - enable versioning on foo.dropme
+ok 78 - foo.dropme is versioned
+ok 79 - foo.dropme can only be drop with CASCADE
+WARNING:  Table foo.dropme does not exist
+ok 80 - foo.dropme is not versioned after drop cascade
+WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
+ok 81 - foo.dropme is not versioned after re-create
+ok 82 - can create version trigger on foo.dropme
+ok 83 - foo.dropme is not versioned after re-create and create_version_trigger
+ok 84 - Function table_version.ver_version() should exist

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -84,6 +84,6 @@ ok 80 - foo.dropme is not versioned after drop cascade
 WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
 ok 81 - foo.dropme is not versioned after re-create
 ok 82 - can enable versioning on drop-recreated table foo.dropme
-ok 83 - foo.dropme is not versioned after re-create and ver_enable_versioning
+ok 83 - foo.dropme is versioned after re-create and ver_enable_versioning
 ok 84 - ver_enable_versioning throws when called on already-versioned table
 ok 85 - Function table_version.ver_version() should exist

--- a/test/expected/base.out
+++ b/test/expected/base.out
@@ -1,5 +1,5 @@
 \set ECHO none
-1..85
+1..93
 ok 1 - Schema table_version should exist
 ok 2 - Should have revision table
 ok 3 - Should have tables_changed table
@@ -78,12 +78,24 @@ ok 75 - Diff function between fOo.Bar3 and foO.bAr4
 ok 76 - Diff function between fOo.Bar3 and foO.bAr4 (with unique column)
 ok 77 - enable versioning on foo.dropme
 ok 78 - foo.dropme is versioned
-ok 79 - foo.dropme can only be drop with CASCADE
+ok 79 - foo.dropme is returned by ver_get_versioned_tables
+ok 80 - foo.dropme versioned table key is "id"
+ok 81 - foo.dropme can only be drop with CASCADE
 WARNING:  Table foo.dropme does not exist
-ok 80 - foo.dropme is not versioned after drop cascade
+ok 82 - foo.dropme is not versioned after drop cascade
+WARNING:  Table foo.dropme does not exist
+ok 83 - foo.dropme is not returned by ver_get_versioned_tables after drop
+WARNING:  Table foo.dropme does not exist
+ok 84 - foo.dropme versioned table key is null after drop
 WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
-ok 81 - foo.dropme is not versioned after re-create
-ok 82 - can enable versioning on drop-recreated table foo.dropme
-ok 83 - foo.dropme is versioned after re-create and ver_enable_versioning
-ok 84 - ver_enable_versioning throws when called on already-versioned table
-ok 85 - Function table_version.ver_version() should exist
+ok 85 - foo.dropme is not versioned after re-create
+WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
+ok 86 - foo.dropme is not returned by ver_get_versioned_tables after re-create
+WARNING:  Table foo.dropme is known as versioned but lacks versioning triggers
+ok 87 - foo.dropme versioned table key is null after re-create
+ok 88 - can enable versioning on drop-recreated table foo.dropme
+ok 89 - foo.dropme is versioned after re-create and ver_enable_versioning
+ok 90 - foo.dropme is returned by ver_get_versioned_tables after re-create and ver_enable_versioning
+ok 91 - foo.dropme versioned table key is "id" after re-create and ver_enable_versioning
+ok 92 - ver_enable_versioning throws when called on already-versioned table
+ok 93 - Function table_version.ver_version() should exist

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(84);
+SELECT plan(85);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -404,10 +404,14 @@ SELECT ok(NOT table_version.ver_is_table_versioned('foo', 'dropme'),
 CREATE TABLE foo.dropme (id INTEGER NOT NULL PRIMARY KEY, d1 TEXT);
 SELECT ok(NOT table_version.ver_is_table_versioned('foo', 'dropme'),
   'foo.dropme is not versioned after re-create');
-SELECT ok(table_version.ver_create_version_trigger('foo','dropme','id'),
-  'can create version trigger on foo.dropme');
+SELECT ok(table_version.ver_enable_versioning('foo','dropme'),
+  'can enable versioning on drop-recreated table foo.dropme');
 SELECT ok(table_version.ver_is_table_versioned('foo', 'dropme'),
-  'foo.dropme is not versioned after re-create and create_version_trigger');
+  'foo.dropme is not versioned after re-create and ver_enable_versioning');
+SELECT throws_like(
+  $$ SELECT table_version.ver_enable_versioning('foo','dropme') $$,
+  'Table % is already versioned',
+  'ver_enable_versioning throws when called on already-versioned table');
 
 ----
 

--- a/test/sql/base.sql
+++ b/test/sql/base.sql
@@ -407,7 +407,7 @@ SELECT ok(NOT table_version.ver_is_table_versioned('foo', 'dropme'),
 SELECT ok(table_version.ver_enable_versioning('foo','dropme'),
   'can enable versioning on drop-recreated table foo.dropme');
 SELECT ok(table_version.ver_is_table_versioned('foo', 'dropme'),
-  'foo.dropme is not versioned after re-create and ver_enable_versioning');
+  'foo.dropme is versioned after re-create and ver_enable_versioning');
 SELECT throws_like(
   $$ SELECT table_version.ver_enable_versioning('foo','dropme') $$,
   'Table % is already versioned',

--- a/test/sql/preparedb.in
+++ b/test/sql/preparedb.in
@@ -1,7 +1,7 @@
 \pset format unaligned
 \pset tuples_only true
 \set QUIET true
-\set VERBOSITY verbose
+\set VERBOSITY terse
 SET client_min_messages TO WARNING;
 CREATE EXTENSION IF NOT EXISTS pgtap;
 CREATE EXTENSION IF NOT EXISTS table_version @@FROM_VERSION@@;


### PR DESCRIPTION
This happens on drop and re-create of a table.
See #57