### PR TITLE
Add test for non-extension install, expose via "make check"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
   - TABLE_VERSION_EXT_DIR=. make check || { cat regression.diffs; false; }
   - sudo env "PATH=$PATH" make install
   - PGPORT=5432 make installcheck || { cat regression.diffs; false; }
+  - PGPORT=5432 make installcheck-noext || { cat regression.diffs; false; }
   # Test upgrades from all tagged versions
   - PGPORT=5432 test/ci/test_all_upgrades.sh
   # Test build and install from package.

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   # Test https://github.com/linz/postgresql-tableversion/issues/47
   - git tag -a "travis/1.2.3-4-gdeadbeef" -m "test"
   - make
+  - TABLE_VERSION_EXT_DIR=. make check || { cat regression.diffs; false; }
   - sudo env "PATH=$PATH" make install
   - PGPORT=5432 make installcheck || { cat regression.diffs; false; }
   # Test upgrades from all tagged versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ script:
   - TABLE_VERSION_EXT_DIR=. make check || { cat regression.diffs; false; }
   - sudo env "PATH=$PATH" make install
   - PGPORT=5432 make installcheck || { cat regression.diffs; false; }
-  - PGPORT=5432 make installcheck-noext || { cat regression.diffs; false; }
+  - PGPORT=5432 make installcheck-loader || { cat regression.diffs; false; }
+  - PGPORT=5432 make installcheck-loader-noext || { cat regression.diffs; false; }
   # Test upgrades from all tagged versions
   - PGPORT=5432 test/ci/test_all_upgrades.sh
   # Test build and install from package.

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test/sql/preparedb: test/sql/preparedb.in
 
 check: check-noext
 
-check-noext:
+check-noext: table_version-loader
 	PREPAREDB_NOEXTENSION=1 $(MAKE) test/sql/preparedb
 	dropdb --if-exists contrib_regression
 	createdb contrib_regression
@@ -122,6 +122,14 @@ check-noext:
 
 installcheck-upgrade:
 	PREPAREDB_UPGRADE=1 make installcheck
+
+installcheck-noext: table_version-loader
+	PREPAREDB_NOEXTENSION=1 make test/sql/preparedb
+	dropdb --if-exists contrib_regression
+	createdb contrib_regression
+	./table_version-loader contrib_regression
+	$(pg_regress_installcheck) $(REGRESS_OPTS) --use-existing $(REGRESS)
+	dropdb contrib_regression
 
 .PHONY: upgrade-scripts
 upgrade-scripts: $(EXTENSION)--$(EXTVERSION).sql

--- a/Makefile
+++ b/Makefile
@@ -123,13 +123,16 @@ check-noext: table_version-loader
 installcheck-upgrade:
 	PREPAREDB_UPGRADE=1 make installcheck
 
-installcheck-noext: table_version-loader
+installcheck-loader: table_version-loader
 	PREPAREDB_NOEXTENSION=1 make test/sql/preparedb
 	dropdb --if-exists contrib_regression
 	createdb contrib_regression
-	./table_version-loader contrib_regression
+	`pg_config --bindir`/table_version-loader $(TABLE_VERSION_OPTS) contrib_regression
 	$(pg_regress_installcheck) $(REGRESS_OPTS) --use-existing $(REGRESS)
 	dropdb contrib_regression
+
+installcheck-loader-noext: table_version-loader
+	$(MAKE) installcheck-loader TABLE_VERSION_OPTS=--no-extension
 
 .PHONY: upgrade-scripts
 upgrade-scripts: $(EXTENSION)--$(EXTVERSION).sql

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ ifeq ($(PG91),yes)
 
 SCRIPTS_built = $(EXTENSION)-loader
 
+# This is a workaround for a bug in "install" rule in
+# PostgreSQL 9.4 and lower
+SCRIPTS = $(SCRIPTS_built)
+
 DATA_built = \
   $(EXTENSION)--$(EXTVERSION).sql \
   $(EXTENSION)-$(EXTVERSION).sql.tpl \

--- a/sql/noextension.sql.in
+++ b/sql/noextension.sql.in
@@ -15,7 +15,13 @@ BEGIN
   --FROM pg_settings WHERE name = 'search_path';
   EXECUTE 'SHOW search_path' INTO cur_search_path;
   EXECUTE 'SET search_path = table_version, ' || cur_search_path;
+
+  IF NOT EXISTS (
+    SELECT * FROM pg_catalog.pg_namespace WHERE nspname =
+    '@extschema@'
+  )
+  THEN
+    CREATE SCHEMA @extschema@;
+  END IF;
 END
 $$ LANGUAGE 'plpgsql';
-
-CREATE SCHEMA IF NOT EXISTS @extschema@;

--- a/table_version-loader.sh
+++ b/table_version-loader.sh
@@ -5,9 +5,12 @@ TGT_DB=
 EXT_MODE=on
 EXT_NAME=table_version
 EXT_DIR=`pg_config --sharedir`/extension/
-VER=`grep default_version ${EXT_DIR}/${EXT_NAME}.control | sed "s/[^']*'//;s/'.*//"`
-TPL_FILE=${EXT_DIR}/${EXT_NAME}-${VER}.sql.tpl
+TPL_FILE=
+VER=
 
+if test -n "$TABLE_VERSION_EXT_DIR"; then
+  EXT_DIR="$TABLE_VERSION_EXT_DIR"
+fi
 
 while test -n "$1"; do
   if test "$1" = "--no-extension"; then
@@ -21,6 +24,19 @@ while test -n "$1"; do
   fi
   shift
 done
+
+if test -z "${VER}"; then
+# TPL_FILE is expected to have the following format:
+#   table_version-1.4.0dev.sql.tpl
+  VER=`ls ${EXT_DIR}/${EXT_NAME}-*.sql.tpl | sed "s/^.*${EXT_NAME}-//;s/\.sql\.tpl//" | tail -1`
+  if test -z "${VER}"; then
+    echo "Cannot find template loader, maybe set TABLE_VERSION_EXT_DIR?" >&2
+    exit 1
+  fi
+fi
+
+TPL_FILE=${EXT_DIR}/${EXT_NAME}-${VER}.sql.tpl
+
 
 if test -z "$TGT_DB"; then
   echo "Usage: $0 [--no-extension] [--version <ver>] <dbname>" >&2


### PR DESCRIPTION
Also makes table_version-loader.hs support env variable
TABLE_VERSION_TPL_FILE to locate the template file

Have travis test the check rule before installing