### PR TITLE
[debian] mark packages as providing "posgresql-tableversion"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Git: git://github.com/linz/postgresql-tableversion.git
 Vcs-Browser: https://github.com/linz/postgresql-tableversion
 
 Package: postgresql-9.3-tableversion
+Provides: postgresql-tableversion
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.3
@@ -21,6 +22,7 @@ Description: PostgreSQL table versioning extension, recording row modifications
  provide access to the row revisions
 
 Package: postgresql-9.4-tableversion
+Provides: postgresql-tableversion
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.4
@@ -32,6 +34,7 @@ Description: PostgreSQL table versioning extension, recording row modifications
  provide access to the row revisions
 
 Package: postgresql-9.5-tableversion
+Provides: postgresql-tableversion
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.5
@@ -43,9 +46,22 @@ Description: PostgreSQL table versioning extension, recording row modifications
  provide access to the row revisions
 
 Package: postgresql-9.6-tableversion
+Provides: postgresql-tableversion
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.6
+Recommends:
+Description: PostgreSQL table versioning extension, recording row modifications
+ and its history. The extension provides APIs for accessing snapshots of a table
+ at certain revisions and the difference generated between any two given
+ revisions. The extension uses a PL/PgSQL trigger based system to record and
+ provide access to the row revisions
+
+Package: postgresql-10-tableversion
+Provides: postgresql-tableversion
+Architecture: all
+Depends: ${misc:Depends},
+         postgresql-10
 Recommends:
 Description: PostgreSQL table versioning extension, recording row modifications
  and its history. The extension provides APIs for accessing snapshots of a table

--- a/debian/control.in
+++ b/debian/control.in
@@ -10,6 +10,7 @@ Vcs-Git: git://github.com/linz/postgresql-tableversion.git
 Vcs-Browser: https://github.com/linz/postgresql-tableversion
 
 Package: postgresql-PGVERSION-tableversion
+Provides: postgresql-tableversion
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-PGVERSION


### PR DESCRIPTION
Should help encoding depedency on the postgresql-version-agnostic
portions of the package (linz-bde-schema, linz-lds-bde-schema)