### PR TITLE
Make ver_{enable,disable}_versioning security definers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ in this file.
 ### IMPORTANT
 - If coming from 1.3.0, 1.3.1 or 1.4.0, make sure to call
   `SELECT ver_fix_revision_disorder()` right after upgrade
+### Changed
+- Functions `ver_enable_versioning` and `ver_disable_versioning`
+  are now security definer, allowing `table_version`usage to
+  under-provileged users: as long as you own a table you can
+  now also version/unversion it (#100)
 ### Improved
 - Loader script made tolerant to already-loaded extension
 - Testing framework switched to `pg_prove` (#74)

--- a/sql/02-disable_versioning.sql
+++ b/sql/02-disable_versioning.sql
@@ -1,26 +1,51 @@
-
+-- {
 CREATE OR REPLACE FUNCTION ver_disable_versioning(
-    p_schema NAME, 
-    p_table  NAME
+    p_table_oid       REGCLASS
 ) 
 RETURNS BOOLEAN AS
 $$
+DECLARE
+    v_schema NAME;
+    v_table  NAME;
+    v_owner  NAME;
 BEGIN
-    IF NOT (SELECT @extschema@.ver_is_table_versioned(p_schema, p_table)) THEN
-        RAISE EXCEPTION 'Table %.% is not versioned', quote_ident(p_schema), quote_ident(p_table);
+
+    SELECT
+      n.nspname, c.relname, r.rolname
+    INTO
+      v_schema, v_table, v_owner
+    FROM
+      pg_namespace n, pg_class c, pg_roles r
+    WHERE
+      c.oid = p_table_oid
+    AND
+      r.oid = c.relowner
+    AND
+      n.oid = c.relnamespace;
+
+    -- Check that SESSION_USER is the owner of the table, or
+    -- refuse to enable versioning on this table
+    IF NOT pg_has_role(session_user, v_owner, 'usage') THEN
+        RAISE EXCEPTION 'User % cannot disable versioning on table %'
+            ' for lack of usage privileges on table owner role %',
+            session_user, p_table_oid, v_owner;
+    END IF;
+
+    IF NOT (SELECT @extschema@.ver_is_table_versioned(v_schema, v_table)) THEN
+        RAISE EXCEPTION 'Table %.% is not versioned', quote_ident(v_schema), quote_ident(v_table);
     END IF;
     
     UPDATE @extschema@.versioned_tables
     SET    versioned = FALSE
-    WHERE  schema_name = p_schema
-    AND    table_name = p_table;
+    WHERE  schema_name = v_schema
+    AND    table_name = v_table;
 
-    EXECUTE 'DROP TRIGGER IF EXISTS '  || @extschema@._ver_get_version_trigger(p_schema, p_table) || ' ON ' ||  
-        quote_ident(p_schema) || '.' || quote_ident(p_table);
-    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@.ver_get_version_table_full(p_schema, p_table) || '()';
-    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@._ver_get_diff_function(p_schema, p_table);
-    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@._ver_get_revision_function(p_schema, p_table);
-    EXECUTE 'DROP TABLE IF EXISTS '    || @extschema@.ver_get_version_table_full(p_schema, p_table) || ' CASCADE';    
+    EXECUTE 'DROP TRIGGER IF EXISTS '  || @extschema@._ver_get_version_trigger(v_schema, v_table) || ' ON ' ||  
+        quote_ident(v_schema) || '.' || quote_ident(v_table);
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@.ver_get_version_table_full(v_schema, v_table) || '()';
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@._ver_get_diff_function(v_schema, v_table);
+    EXECUTE 'DROP FUNCTION IF EXISTS ' || @extschema@._ver_get_revision_function(v_schema, v_table);
+    EXECUTE 'DROP TABLE IF EXISTS '    || @extschema@.ver_get_version_table_full(v_schema, v_table) || ' CASCADE';    
 
     EXECUTE 'WITH deleted AS ('
             ' DELETE FROM table_version.versioned_tables'
@@ -28,9 +53,14 @@ BEGIN
             ' AND table_name=$2 RETURNING id'
             ') DELETE FROM table_version.tables_changed'
             '  WHERE table_id in ( select * from deleted )'
-    USING p_schema, p_table;
+    USING v_schema, v_table;
     
     RETURN TRUE;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+--}
 
+CREATE OR REPLACE FUNCTION ver_disable_versioning(p_schema NAME, p_table  NAME)
+RETURNS BOOLEAN AS $$
+  SELECT @extschema@.ver_disable_versioning(( p_schema || '.' || p_table)::regclass);
+$$ LANGUAGE sql;

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(119);
+SELECT plan(125);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -315,7 +315,10 @@ SELECT results_eq(
 );
 
 CREATE ROLE test_owner;
+GRANT USAGE on SCHEMA foo to test_owner;
+
 CREATE ROLE test_user;
+GRANT USAGE on SCHEMA foo to test_user;
 
 CREATE TABLE foo.bar5 (
     baz INTEGER NOT NULL PRIMARY KEY,
@@ -341,6 +344,50 @@ SELECT ok(table_version.ver_disable_versioning('foo', 'bar5'), 'Disable versioni
 
 SELECT is_empty('SELECT * FROM table_version.tables_changed', 'tables_changed is empty after ver_disable_version');
 SELECT is_empty('SELECT * FROM table_version.versioned_tables', 'versioned_tables is empty after ver_disable_version');
+
+-- Now try again as the owner user
+
+SET SESSION AUTHORIZATION test_owner;
+
+SELECT ok(table_version.ver_enable_versioning('foo', 'bar5'),
+    'Enable versioning on table as the unprivileged table owner');
+
+SELECT table_owner_is(
+    'table_version', 'foo_bar5_revision', 'test_owner',
+    'Test foo_bar5_revision ownership'
+);
+
+SELECT table_privs_are(
+    'table_version', 'foo_bar5_revision', 'test_user',
+    ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE'],
+    'Test foo_bar5_revision permission for test_user'
+);
+
+SET SESSION AUTHORIZATION test_user;
+
+SELECT throws_like($$
+  SELECT table_version.ver_disable_versioning('foo', 'bar5') $$,
+  '% table owner role %',
+  'Unexpected exception from non-owner attempt at unversioning table');
+
+RESET SESSION AUTHORIZATION;
+
+SELECT ok(table_version.ver_disable_versioning('foo', 'bar5'),
+    'Disable versioning on foo.bar5 as table owner');
+
+RESET SESSION AUTHORIZATION;
+
+-- Check that non-owner user cannot version/unversion the table
+SET SESSION AUTHORIZATION test_user;
+
+SELECT throws_like($$
+  SELECT table_version.ver_enable_versioning('foo', 'bar5') $$,
+  '% table owner role %',
+  'Unexpected exception from non-owner attempt at versioning table');
+
+RESET SESSION AUTHORIZATION;
+
+
 
 DROP TABLE foo.bar;
 DROP TABLE foo.bar2;


### PR DESCRIPTION
Only allow toggling versioning of a table to users having
usage privilege on the table owner role.

See #100