### PR TITLE
Fix ver_fix_revision_disorder implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes for the PostgreSQL table version extension are documented
 in this file.
 
+## [1.3.3] - YYYY-MM-DD
+### Fixed
+- Fix db corruption by `ver_fix_revision_disorder` (#115)
+
 ## [1.3.2] - 2018-02-19
 ### IMPORTANT
 - If coming from 1.3.0 or 1.3.1, make sure to call

--- a/sql/17-fix_revision_disorder.sql
+++ b/sql/17-fix_revision_disorder.sql
@@ -42,7 +42,7 @@ BEGIN
           v_numversionedtables, v_rec.schema_name, v_rec.table_name);
       EXECUTE format('PREPARE "p_ue%s" AS '
           'UPDATE table_version.%s_%s_revision '
-          'SET _revision_created = $1 WHERE _revision_created = $2',
+          'SET _revision_expired = $1 WHERE _revision_expired = $2',
           v_numversionedtables, v_rec.schema_name, v_rec.table_name);
       v_numversionedtables := v_numversionedtables + 1;
     EXCEPTION WHEN UNDEFINED_TABLE THEN


### PR DESCRIPTION
Was failing to update _revision_expired field correctly.
Closes #115 in 1.3 branch