### PR TITLE
Do not force revisioned table trigger to be owned by table owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ in this file.
   `SELECT ver_fix_revision_disorder()` right after upgrade
 ### Changed
 - Functions `ver_enable_versioning`, `ver_disable_versioning`
-  `ver_versioned_table_add_column`, `ver_versioned_table_drop_column`
-  and `ver_versioned_table_change_column_type` are now security definer,
+  `ver_versioned_table_add_column`, `ver_versioned_table_drop_column`,
+  `ver_versioned_table_change_column_type` and
+  `ver_create_version_trigger` are now security definer,
   allowing `table_version` usage to under-provileged users: as long as
   you own a table you can now also version/unversion (#100) and
   add/drop/change cols on it (#113)
@@ -27,6 +28,7 @@ in this file.
     - `ver_versioned_table_add_column`
     - `ver_versioned_table_drop_column`
     - `ver_versioned_table_change_column_type`
+    - `ver_create_version_trigger`
 
 ## [1.4.0] - 2017-11-15
 ### Added

--- a/sql/01-enable_versioning.sql
+++ b/sql/01-enable_versioning.sql
@@ -241,7 +241,7 @@ BEGIN
     END IF;
 
     PERFORM @extschema@.ver_create_table_functions(v_schema, v_table, v_key_col);
-    PERFORM @extschema@.ver_create_version_trigger(v_schema, v_table, v_key_col);
+    PERFORM @extschema@.ver_create_version_trigger(p_table_oid, v_key_col);
     
     RETURN TRUE;
 END;

--- a/sql/09-table_change_column_type.sql
+++ b/sql/09-table_change_column_type.sql
@@ -56,7 +56,7 @@ BEGIN
         table_name = v_table;
     
     PERFORM @extschema@.ver_create_table_functions(v_schema, v_table, v_key_col);
-    PERFORM @extschema@.ver_create_version_trigger(v_schema, v_table, v_key_col);
+    PERFORM @extschema@.ver_create_version_trigger(p_table_oid, v_key_col);
     RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/sql/10-table_add_column.sql
+++ b/sql/10-table_add_column.sql
@@ -57,7 +57,7 @@ BEGIN
         table_name = v_table;
     
     PERFORM @extschema@.ver_create_table_functions(v_schema, v_table, v_key_col);
-    PERFORM @extschema@.ver_create_version_trigger(v_schema, v_table, v_key_col);
+    PERFORM @extschema@.ver_create_version_trigger(p_table_oid, v_key_col);
     RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/sql/13-create_version_trigger.sql
+++ b/sql/13-create_version_trigger.sql
@@ -181,9 +181,6 @@ $TRIGGER$ LANGUAGE plpgsql SECURITY DEFINER;
         quote_ident(p_schema) || '.' || quote_ident(p_table) ||
         ' FOR EACH ROW EXECUTE PROCEDURE ' || v_revision_table || '()';
     
-    EXECUTE 'ALTER FUNCTION ' || v_revision_table || '() ' ||
-        'OWNER TO ' || @extschema@._ver_get_table_owner((p_schema || '.' || p_table)::REGCLASS);
-    
     RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/16-table_drop_column.sql
+++ b/sql/16-table_drop_column.sql
@@ -50,7 +50,7 @@ BEGIN
         table_name = v_table;
     
     PERFORM @extschema@.ver_create_table_functions(v_schema, v_table, v_key_col);
-    PERFORM @extschema@.ver_create_version_trigger(v_schema, v_table, v_key_col);
+    PERFORM @extschema@.ver_create_version_trigger(p_table_oid, v_key_col);
     RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -436,8 +436,6 @@ RESET SESSION AUTHORIZATION;
 SELECT ok(table_version.ver_disable_versioning('foo', 'bar5'),
     'Disable versioning on foo.bar5 as table owner');
 
-RESET SESSION AUTHORIZATION;
-
 -- Check that non-owner user cannot version/unversion the table
 SET SESSION AUTHORIZATION test_user;
 

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(156);
+SELECT plan(160);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -407,6 +407,12 @@ SELECT is(table_version.ver_versioned_table_add_column('foo', 'bar5', 'c3', 'int
 SELECT is(table_version.ver_versioned_table_change_column_type('foo', 'bar5', 'c3', 'int4'),
     TRUE, 'Revisioned table owner can change column type');
 
+-- Check that owner can regenerate version triggers
+SELECT is(table_version.ver_create_version_trigger('foo', 'bar5', 'baz'),
+    TRUE, 'Table owner can regenerate version triggers');
+SELECT is(table_version.ver_create_version_trigger('foo.bar5', 'baz'),
+    TRUE, 'Table owner can regenerate version triggers (regclass version)');
+
 SET SESSION AUTHORIZATION test_user;
 
 SELECT throws_like($$
@@ -414,7 +420,7 @@ SELECT throws_like($$
   '% table owner role %',
   'Unexpected exception from non-owner attempt at unversioning table');
 
--- Check that non-owner can NOT add / drop columns
+-- Check that non-owner can NOT add / drop / change columns
 SELECT throws_like($$ SELECT
     table_version.ver_versioned_table_add_column('foo', 'bar5', 'c2', 'TEXT')
     $$,
@@ -430,6 +436,13 @@ SELECT throws_like($$ SELECT
     $$,
     '% table owner role %',
     'Revisioned table non-owner can not change column type');
+
+-- Check that non-owner can NOT add version triggers
+SELECT throws_like($$ SELECT
+    table_version.ver_create_version_trigger('foo', 'bar5', 'baz')
+    $$,
+    '% table owner role %',
+    'Table non-owner can not create version triggers');
 
 RESET SESSION AUTHORIZATION;
 
@@ -570,6 +583,7 @@ SELECT has_function( 'table_version', 'ver_disable_versioning', ARRAY['regclass'
 SELECT has_function( 'table_version', 'ver_versioned_table_add_column', ARRAY['regclass', 'name', 'text'] );
 SELECT has_function( 'table_version', 'ver_versioned_table_drop_column', ARRAY['regclass', 'name'] );
 SELECT has_function( 'table_version', 'ver_versioned_table_change_column_type', ARRAY['regclass', 'name', 'text'] );
+SELECT has_function( 'table_version', 'ver_create_version_trigger', ARRAY['regclass', 'name'] );
 
 
 -- Added after problem found in admin_bouldaries_uploader


### PR DESCRIPTION
Rather, let it be owned by the caller of ver_create_version_trigger
which is tipically the `table_version` extension owner as the definer
of security-definer functions `ver_enable_versioning`,
`ver_versioned_table_add_column` and `ver_versioned_table_drop_column`

Fixes #99