### PR TITLE
Automatically update revisioned table triggers when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,15 @@ installcheck-loader: $(TESTS_built) table_version-loader
 	pg_prove -d contrib_regression test/sql
 	dropdb contrib_regression
 
+#
+# Check functionality when loading and upgrading via table_version-loader
+#
+# Version to upgrade from MUST be specified via PREPAREDB_UPGRADE_FROM
+# environment variable.
+#
+# Custom switches can be passed to table_version-loader via the
+# TABLE_VERSION_OPTS env variable (for example --no-extension)
+#
 installcheck-loader-upgrade: $(TESTS_built) table_version-loader
 	PREPAREDB_NOEXTENSION=1 $(MAKE) test/sql/preparedb
 	dropdb --if-exists contrib_regression

--- a/Makefile
+++ b/Makefile
@@ -134,17 +134,17 @@ test/sql/version.pg: Makefile
 test/sql/preparedb: test/sql/preparedb.in
 	cat $< | \
 	  if test "${PREPAREDB_UPGRADE}" = 1; then \
-      if test -n "${PREPAREDB_UPGRADE_FROM}"; then \
-        UPGRADE_FROM="version '${PREPAREDB_UPGRADE_FROM}'"; \
-      else \
-        UPGRADE_FROM=""; \
-      fi; \
-      $(SED) -e 's/^--UPGRADE-- //' -e "s/@@FROM_VERSION@@/$$UPGRADE_FROM/"; \
+        if test -n "${PREPAREDB_UPGRADE_FROM}"; then \
+          UPGRADE_FROM="version '${PREPAREDB_UPGRADE_FROM}'"; \
+        else \
+          UPGRADE_FROM=""; \
+        fi; \
+        $(SED) -e 's/^--UPGRADE-- //' -e "s/@@FROM_VERSION@@/$$UPGRADE_FROM/"; \
 	  elif test "${PREPAREDB_NOEXTENSION}" = 1; then \
-      grep -v table_version; \
-    else \
-      cat; \
-    fi | \
+        grep -v table_version; \
+      else \
+        cat; \
+      fi | \
 	  $(SED) -e 's/@@VERSION@@/$(EXTVERSION)/' -e 's/@@FROM_VERSION@@//' > $@
 
 check: check-noext

--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,10 @@ check-noext: $(TESTS_built) table_version-loader
 	dropdb contrib_regression
 
 installcheck-upgrade:
-	PREPAREDB_UPGRADE=1 make installcheck
+	PREPAREDB_UPGRADE=1 $(MAKE) installcheck
 
 installcheck-loader: $(TESTS_built) table_version-loader
-	PREPAREDB_NOEXTENSION=1 make test/sql/preparedb
+	PREPAREDB_NOEXTENSION=1 $(MAKE) test/sql/preparedb
 	dropdb --if-exists contrib_regression
 	createdb contrib_regression
 	PATH="$$PATH:$(LOCAL_BINDIR)" table_version-loader $(TABLE_VERSION_OPTS) contrib_regression

--- a/Makefile
+++ b/Makefile
@@ -182,13 +182,16 @@ installcheck-loader-upgrade: $(TESTS_built) table_version-loader
 	createdb contrib_regression
 	PATH="$$PATH:$(LOCAL_BINDIR)" \
 	TABLE_VERSION_EXT_DIR=$(PREPAREDB_UPGRADE_FROM_EXT_DIR) \
-	    table_version-loader $(TABLE_VERSION_OPTS) contrib_regression
+	    table_version-loader --version $(PREPAREDB_UPGRADE_FROM) \
+        $(TABLE_VERSION_OPTS) contrib_regression
 	psql -f test/sql/preparedb contrib_regression
 	rm -rf test/sql-loader-upgrade
 	cp -a test/sql test/sql-loader-upgrade
 	psql -f test/sql/preparedb contrib_regression
 	psql -f test/sql/upgrade-pre.sql contrib_regression
-	PATH="$$PATH:$(LOCAL_BINDIR)" table_version-loader $(TABLE_VERSION_OPTS) contrib_regression
+	PATH="$$PATH:$(LOCAL_BINDIR)" \
+		table_version-loader --version $(EXTVERSION) \
+		$(TABLE_VERSION_OPTS) contrib_regression
 	psql -f test/sql/upgrade-post.sql contrib_regression
 	sed -ie 's/^\\i test.sql.preparedb//' test/sql-loader-upgrade/base.pg
 	pg_prove -d contrib_regression test/sql-loader-upgrade

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ DISTFILES = \
 
 SED = sed
 
+# List of known versions from which we're capable
+# to upgrade automatically from. This should be
+# any version from 1.2.0 onward.
+#
 UPGRADEABLE_VERSIONS = \
     1.2.0 \
     1.3.0dev 1.3.0 1.3.1dev 1.3.1 \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ DISTFILES = \
 
 SED = sed
 
-UPGRADEABLE_VERSIONS = 1.2.0 1.3.0dev 1.3.0 1.4.0dev 1.4.0 1.5.0dev
+UPGRADEABLE_VERSIONS = \
+    1.2.0 \
+    1.3.0dev 1.3.0 1.3.1dev 1.3.1 \
+    1.4.0dev 1.4.0 1.4.1dev 1.4.1 1.4.2dev 1.4.2 1.4.3dev 1.4.3 \
+    1.5.0dev
 
 SQLSCRIPTS_built = \
     sql/20-version.sql \

--- a/table_version-loader.sh
+++ b/table_version-loader.sh
@@ -35,9 +35,6 @@ if test -z "${VER}"; then
   fi
 fi
 
-TPL_FILE=${EXT_DIR}/${EXT_NAME}-${VER}.sql.tpl
-
-
 if test -z "$TGT_DB"; then
   echo "Usage: $0 [--no-extension] [--version <ver>] <dbname>" >&2
   exit 1
@@ -64,6 +61,8 @@ if test "${EXT_MODE}" = 'on'; then cat<<EOF | psql -tA --set ON_ERROR_STOP=1
   \$\$ LANGUAGE 'plpgsql';
 EOF
 else
+  TPL_FILE=${EXT_DIR}/${EXT_NAME}-${VER}.sql.tpl
+  echo "Using template file ${TPL_FILE}"
   cat ${TPL_FILE} | sed "s/@extschema@/${TGT_SCHEMA}/g" |
   psql --set ON_ERROR_STOP=1 > /dev/null
 fi

--- a/table_version-loader.sh
+++ b/table_version-loader.sh
@@ -62,7 +62,12 @@ if test "${EXT_MODE}" = 'on'; then cat<<EOF | psql -tA --set ON_ERROR_STOP=1
 EOF
 else
   TPL_FILE=${EXT_DIR}/${EXT_NAME}-${VER}.sql.tpl
-  echo "Using template file ${TPL_FILE}"
-  cat ${TPL_FILE} | sed "s/@extschema@/${TGT_SCHEMA}/g" |
-  psql --set ON_ERROR_STOP=1 > /dev/null
+  if test -r ${TPL_FILE}; then
+    echo "Using template file ${TPL_FILE}"
+    cat ${TPL_FILE} | sed "s/@extschema@/${TGT_SCHEMA}/g" |
+    psql --set ON_ERROR_STOP=1 > /dev/null
+  else
+    echo "Template file ${TPL_FILE} is not readable or does not exist" >&2
+    exit 1
+  fi
 fi

--- a/table_version-loader.sh
+++ b/table_version-loader.sh
@@ -16,7 +16,7 @@ while test -n "$1"; do
   if test "$1" = "--no-extension"; then
     EXT_MODE=off
   elif test "$1" = "--version"; then
-    VER=$1; shift
+    shift; VER=$1
   elif test -z "${TGT_DB}"; then
     TGT_DB=$1
   else

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -9,10 +9,10 @@ cd `dirname $0`/../../
 VER="1.1.0 1.1.1 1.1.2 1.1.3 1.2.0 1.3.0 1.3.1 1.4.0 1.4.1 1.4.2 1.4.3";
 
 TMP_INSTALL_DIR_PREFIX=/tmp/table_version
-mkdir -p ${TMP_INSTALL_DIR_PREFIX}
+mkdir -p ${TMP_INSTALL_DIR_PREFIX} || exit 1
 
 # Save current table_version
-cp -a `which table_version-loader` ${TMP_INSTALL_DIR_PREFIX}
+cp -a `which table_version-loader` ${TMP_INSTALL_DIR_PREFIX} || exit 1
 
 # Install all older versions
 git fetch --unshallow --tags # to get all commits/tags
@@ -23,15 +23,15 @@ for v in $VER; do
   echo "Installing version $v"
   echo "-------------------------------------"
   git checkout $v && git clean -dxf && make install || exit 1
-  mkdir -p ${TMP_INSTALL_DIR_PREFIX}/${v}/share
-  cp -a /usr/local/share/table_version/* ${TMP_INSTALL_DIR_PREFIX}/${v}/share
+  mkdir -p ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
+  cp -a /usr/local/share/table_version/* ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
 done;
 cd ..
 rm -rf older-versions
 
 # Restore current table_version after installing/overriding new one
 # (effectively moving to wherever will be found first)
-cp -a ${TMP_ISTALL_DIR_PREFIX} `which table_version-loader`
+cp -a ${TMP_ISTALL_DIR_PREFIX} `which table_version-loader` || exit 1
 
 # Test upgrade from all older versions
 for v in $VER; do

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -25,7 +25,7 @@ for v in $VER; do
   git checkout $v && git clean -dxf || exit 1
   # Since 1.4.0 we have a loader
   if test `echo $v | tr -d .` -ge 140; then
-    TPL_INSTALL_DIR=`make install | grep tpl  2> /dev/null | sed "s/.* //;s/'$//;s/^'//"`
+    TPL_INSTALL_DIR=`make install | grep tpl | tail -1 | sed "s/.* //;s/'$//;s/^'//"`
     test -n "$TPL_INSTALL_DIR" || exit 1
     mkdir -p ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
     cp -f ${TPL_INSTALL_DIR}/*.tpl ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -9,6 +9,10 @@ cd `dirname $0`/../../
 VER="1.1.0 1.1.1 1.1.2 1.1.3 1.2.0 1.3.0 1.3.1 1.4.0 1.4.1 1.4.2 1.4.3";
 
 TMP_INSTALL_DIR_PREFIX=/tmp/table_version
+mkdir -p ${TMP_INSTALL_DIR_PREFIX}
+
+# Save current table_version
+cp -a `which table_version-loader` ${TMP_INSTALL_DIR_PREFIX}
 
 # Install all older versions
 git fetch --unshallow --tags # to get all commits/tags
@@ -24,6 +28,10 @@ for v in $VER; do
 done;
 cd ..
 rm -rf older-versions
+
+# Restore current table_version after installing/overriding new one
+# (effectively moving to wherever will be found first)
+cp -a ${TMP_ISTALL_DIR_PREFIX} `which table_version-loader`
 
 # Test upgrade from all older versions
 for v in $VER; do

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -6,7 +6,7 @@ cd `dirname $0`/../../
 # Versions/tags known to build
 # NOTE: tag 1.0.1 does not build, so we skip that
 #
-VER="1.1.0 1.1.1 1.1.2 1.1.3 1.2.0";
+VER="1.1.0 1.1.1 1.1.2 1.1.3 1.2.0 1.3.0 1.3.1 1.4.0 1.4.1 1.4.2 1.4.3";
 
 TMP_INSTALL_DIR_PREFIX=/tmp/table_version
 

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -38,7 +38,7 @@ rm -rf older-versions
 
 # Restore current table_version after installing/overriding new one
 # (effectively moving to wherever will be found first)
-cp -a ${TMP_ISTALL_DIR_PREFIX} `which table_version-loader` || exit 1
+cp -a ${TMP_INSTALL_DIR_PREFIX}/table_version-loader `which table_version-loader` || exit 1
 
 # Test upgrade from all older versions
 for v in $VER; do

--- a/test/ci/test_all_upgrades.sh
+++ b/test/ci/test_all_upgrades.sh
@@ -28,7 +28,7 @@ for v in $VER; do
     TPL_INSTALL_DIR=`make install | grep tpl  2> /dev/null | sed "s/.* //;s/'$//;s/^'//"`
     test -n "$TPL_INSTALL_DIR" || exit 1
     mkdir -p ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
-    cp -a ${TPL_INSTALL_DIR}/*.tpl ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
+    cp -f ${TPL_INSTALL_DIR}/*.tpl ${TMP_INSTALL_DIR_PREFIX}/${v}/share || exit 1
   else
     make install || exit 1
   fi

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(160);
+SELECT plan(161);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -363,6 +363,15 @@ SELECT ok(table_version.ver_enable_versioning('foo', 'bar5'), 'Enable versioning
 SELECT table_owner_is(
     'table_version', 'foo_bar5_revision', 'test_owner',
     'Test foo_bar5_revision ownership'
+);
+
+-- Test for https://github.com/linz/postgresql-tableversion/issues/99
+SELECT function_owner_is(
+    'table_version', 'foo_bar5_revision', ARRAY[]::text[],
+    ( SELECT r.rolname FROM pg_proc p, pg_roles r
+      WHERE p.oid = 'table_version.ver_version'::regproc
+        AND r.oid = p.proowner ),
+    'Owner of foo_bar5_revision function should be extension owner'
 );
 
 SELECT table_privs_are(


### PR DESCRIPTION
Calls create_version_trigger again on all tables when coming
from a version earlier than 1.5.0. Closes #130.