### PR TITLE
Add ver_log_modified_tables function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ in this file.
 
 ## [1.7.0dev] - 2019-MM-DD
 ### Added
-...
+- New function `ver_log_modified_tables`
 ### Changed
 - `table_version-loader` will CREATE EXTENSION from unpackaged
   when --no-extension is NOT given and db already has the

--- a/doc/table_version.md
+++ b/doc/table_version.md
@@ -1158,6 +1158,19 @@ call this function multiple times, expecting 0 to be returned after
 the first call (in case of uncommitted transactions there could be
 additional revisions to reorder after the first run).
 
+### `ver_log_modified_tables()` ###
+
+Regenerate the metadata table `table_version.tables_changed` from the
+data in `table_version.versioned_tables` and associated revision
+tables.
+
+This may be useful if the table data gets corrupted for any reason.
+Data in that table is a redundancy used to speed up some queries.
+
+The function takes no parameters and returns void.
+You can safely call this function multiple times.
+
+
 Support
 -------
 

--- a/sql/18-log_modified_tables.sql
+++ b/sql/18-log_modified_tables.sql
@@ -1,0 +1,33 @@
+
+CREATE OR REPLACE FUNCTION ver_log_modified_tables()
+RETURNS VOID
+AS $$
+DECLARE
+    v_version_table VARCHAR;
+    v_rec RECORD;
+BEGIN
+
+    TRUNCATE table_version.tables_changed;
+    FOR v_rec IN SELECT id, schema_name, table_name
+                 FROM table_version.versioned_tables
+                 WHERE versioned
+    LOOP
+        v_version_table := @extschema@.ver_get_version_table(
+                                v_rec.schema_name,
+                                v_rec.table_name);
+        EXECUTE format('INSERT INTO "@extschema@"."tables_changed"'
+            '(table_id, revision) '
+            'SELECT %1$L::int, rev FROM ( '
+            '  SELECT _revision_created rev '
+            '    FROM "@extschema@".%2$I UNION'
+            '  SELECT _revision_expired rev '
+            '    FROM "@extschema@".%2$I '
+            ') foo '
+            '  WHERE rev IS NOT NULL',
+            v_rec.id, v_version_table
+            );
+    END LOOP;
+
+END;
+$$ LANGUAGE plpgsql;
+

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(162);
+SELECT plan(165);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -681,6 +681,29 @@ SELECT lives_ok($$ SELECT table_version.ver_create_revision('r3') $$); -- 3
 SELECT lives_ok($$ UPDATE t set v = 'a3' WHERE k = 1 $$);
 SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
 
+-- Test tables_changed population
+SELECT set_eq($$
+    SELECT r.comment, t.schema_name, t.table_name
+    FROM
+        table_version.tables_changed c,
+        table_version.versioned_tables t,
+        table_version.revision r
+    WHERE c.table_id = t.id
+    AND c.revision = r.id
+$$,
+$$
+    VALUES
+        ('r1', 'public', 't'),
+        ('r3', 'public', 't'),
+        ('r2', 'public', 't')
+$$,
+    'tables_changed is correctly populated after first change of t'
+);
+
+--------------------------
+-- Check revisions
+--------------------------
+
 SELECT isnt_empty($$
   SELECT * FROM table_version.public_t_revision
   WHERE _revision_expired < _revision_created
@@ -702,6 +725,25 @@ $$, 'Ordered revisions are found in public_t_revision');
 
 SELECT is(table_version.ver_fix_revision_disorder(), 0::bigint,
   'no revision moved after fix');
+
+--------------------------
+-- Test log_tables_changed
+--------------------------
+
+CREATE TABLE table_version.tables_changed_backup AS
+    SELECT * FROM table_version.tables_changed;
+
+-- Truncate the tables_changed table
+TRUNCATE table_version.tables_changed;
+
+SELECT lives_ok($$SELECT table_version.ver_log_modified_tables()$$);
+
+-- Test tables_changed_backup equals the newly populated table
+SELECT set_eq(
+    'SELECT * from table_version.tables_changed_backup',
+    'SELECT * from table_version.tables_changed',
+    'log_tables_changed correctly populated the tables_changed table'
+);
 
 ---------------------------------------
 -- Test for table triggers


### PR DESCRIPTION
This is useful if table_version.tables_changed gets lost
for any reason.

I actually wonder if we could turn that table into a view, to
avoid the maintainance effort. \cc @palmerj