### PR TITLE
Updates to security model of ver_complete_revision and ver_delete_revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ in this file.
 - `table_version-loader` will CREATE EXTENSION from unpackaged
   when --no-extension is NOT given and db already has the
   extension-less support (#168)
+- Only the creator of a revision can complete it (#181)
+- In-progress revisions cannot be deleted (#178)
 ### Improved
 - Progress message from `table_version-loader` (#177)
 - Forbid deleting an in-progress revision (#181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ in this file.
 ### Added
 - New function `ver_log_modified_tables`
 - Ability for `table_version-loader` to upgrade between dev versions
+- Ability to delete an empty revision by its creator (#178)
 ### Changed
 - `table_version-loader` will CREATE EXTENSION from unpackaged
   when --no-extension is NOT given and db already has the
   extension-less support (#168)
 ### Improved
 - Progress message from `table_version-loader` (#177)
+- Forbid deleting an in-progress revision (#181)
 
 ## [1.6.0] - 2019-01-09
 ### IMPORTANT

--- a/doc/table_version.md
+++ b/doc/table_version.md
@@ -137,8 +137,8 @@ Revisions are more described in the `table_version.revision` table.
 Security model
 --------------
 
-- Anyone can create and complete revisions (even a different user
-  than the one who crated the revision can complete it).
+- Anyone can create revisions.
+- Revisions can only be completed by their creators.
 - Only those who have ownership privileges on a table can
   enable/disable versioning of such table.
 - Only empty revisions can be deleted.

--- a/doc/table_version.md
+++ b/doc/table_version.md
@@ -138,11 +138,11 @@ Security model
 --------------
 
 - Anyone can create and complete revisions (even a different user
-  than the one who crated the revision can complete it)
+  than the one who crated the revision can complete it).
 - Only those who have ownership privileges on a table can
-  enable/disable versioning of such table
-- Only the owner of `table_version` extension can delete an unused
-  revision
+  enable/disable versioning of such table.
+- Only empty revisions can be deleted.
+- Only the creator of a revision can delete it.
 
 Note that disabling versioning on a table results in all history for
 that table being deleted.

--- a/sql/04-complete_revision.sql
+++ b/sql/04-complete_revision.sql
@@ -1,9 +1,22 @@
 
 CREATE OR REPLACE FUNCTION ver_complete_revision() RETURNS BOOLEAN AS
 $$
+DECLARE
+    v_user_name TEXT;
+
 BEGIN
     IF NOT @extschema@._ver_get_reversion_temp_table('_changeset_revision') THEN
         RETURN FALSE;
+    END IF;
+
+    SELECT user_name
+        FROM @extschema@.revision r, _changeset_revision t
+        WHERE r.id = t.revision
+        INTO v_user_name;
+
+    IF NOT pg_has_role(session_user, v_user_name, 'usage') THEN
+        RAISE EXCEPTION 'In-progress revision can only be completed '
+                        'by its creator user %', v_user_name;
     END IF;
     
     DROP TABLE _changeset_revision;

--- a/sql/05-delete_revision.sql
+++ b/sql/05-delete_revision.sql
@@ -5,18 +5,32 @@ CREATE OR REPLACE FUNCTION ver_delete_revision(
 RETURNS BOOLEAN AS
 $$
 DECLARE
-    v_status BOOLEAN;
+    v_user_name TEXT;
 BEGIN
+    SELECT user_name
+        FROM @extschema@.revision
+        WHERE id = p_revision
+        INTO v_user_name;
+
+    IF NOT FOUND THEN
+        RETURN FALSE;
+    END IF;
+
+    IF NOT pg_has_role(session_user, v_user_name, 'usage') THEN
+        RAISE WARNING 'Can not delete revision % created by user %', p_revision, v_user_name;
+        RETURN FALSE;
+    END IF;
+
+
     BEGIN
         DELETE FROM @extschema@.revision
         WHERE id = p_revision;
-        v_status := FOUND;
+        return TRUE;
     EXCEPTION
         WHEN foreign_key_violation THEN
             RAISE WARNING 'Can not delete revision % as it is referenced by other tables: %', p_revision, SQLERRM;
-            v_status := FALSE;
+            RETURN FALSE;
     END;
-    RETURN v_status;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(165);
+SELECT plan(170);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -766,6 +766,30 @@ SELECT lives_ok($$ INSERT INTO "index" VALUES (2, 'b', '24') $$);
 SELECT lives_ok($$ ALTER TABLE table_version.public_index_revision ADD column "desc2" text; $$);
 -- insert new value
 SELECT lives_ok($$ INSERT INTO "index" VALUES (4, 'b', '24') $$);
+SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
+
+---------------------------------------
+-- Test for revision creation/deletion
+---------------------------------------
+
+SET SESSION AUTHORIZATION test_owner;
+
+SELECT lives_ok($$ SELECT table_version.ver_create_revision('r4') $$);
+SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
+
+SET SESSION AUTHORIZATION test_user;
+
+SELECT results_eq($$
+    SELECT table_version.ver_delete_revision(max(id))
+    FROM table_version.revision
+$$, $$ VALUES (FALSE) $$ );
+
+SET SESSION AUTHORIZATION test_owner;
+
+SELECT results_eq($$
+    SELECT table_version.ver_delete_revision(max(id))
+    FROM table_version.revision
+$$, $$ VALUES (TRUE) $$ );
 
 ---------------------------------------
 -- End of tests

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(170);
+SELECT plan(171);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -775,6 +775,12 @@ SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
 SET SESSION AUTHORIZATION test_owner;
 
 SELECT lives_ok($$ SELECT table_version.ver_create_revision('r4') $$);
+
+SELECT results_eq($$
+    SELECT table_version.ver_delete_revision(max(id))
+    FROM table_version.revision
+$$, $$ VALUES (FALSE) $$, $$ Cannot delete an incomplete revision $$ );
+
 SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
 
 SET SESSION AUTHORIZATION test_user;

--- a/test/sql/base.pg
+++ b/test/sql/base.pg
@@ -18,7 +18,7 @@
 
 BEGIN;
 
-SELECT plan(171);
+SELECT plan(172);
 
 SELECT has_schema( 'table_version' );
 SELECT has_table( 'table_version', 'revision', 'Should have revision table' );
@@ -768,9 +768,9 @@ SELECT lives_ok($$ ALTER TABLE table_version.public_index_revision ADD column "d
 SELECT lives_ok($$ INSERT INTO "index" VALUES (4, 'b', '24') $$);
 SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
 
----------------------------------------
--- Test for revision creation/deletion
----------------------------------------
+-------------------------------------------------------------
+-- Test for revision creation/completion/deletion permissions
+-------------------------------------------------------------
 
 SET SESSION AUTHORIZATION test_owner;
 
@@ -780,6 +780,13 @@ SELECT results_eq($$
     SELECT table_version.ver_delete_revision(max(id))
     FROM table_version.revision
 $$, $$ VALUES (FALSE) $$, $$ Cannot delete an incomplete revision $$ );
+
+SET SESSION AUTHORIZATION test_user;
+
+SELECT throws_like($$ SELECT table_version.ver_complete_revision() $$,
+                   $$% can only be completed by its creator %$$);
+
+SET SESSION AUTHORIZATION test_owner;
 
 SELECT lives_ok($$ SELECT table_version.ver_complete_revision() $$);
 


### PR DESCRIPTION
Turns ver_delete_revision into a security-definer.
Includes docs and testcase.

Closes #178