### PR TITLE
Update revision triggers if coming from 1.7.0 or earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: true
 
 env:
   matrix:
-    - PG=9.3
     - PG=9.4
     - PG=9.5
     - PG=9.6
@@ -24,7 +23,6 @@ before_install:
     postgresql-${PG}-pgtap
     postgresql-server-dev-${PG}
     postgresql-server-dev-all
-    postgresql-server-dev-${PG}
     debhelper fakeroot
     libtap-parser-sourcehandler-pgtap-perl
 


### PR DESCRIPTION
This is to effectively get the new feature of skipping empty updates
Closes #192

To be backported to 1.7 branch