### PR TITLE
Update revision triggers if coming from 1.7.0 or earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: true
 
 env:
   matrix:
-    - PG=9.3
     - PG=9.4
     - PG=9.5
     - PG=9.6
@@ -24,7 +23,6 @@ before_install:
     postgresql-${PG}-pgtap
     postgresql-server-dev-${PG}
     postgresql-server-dev-all
-    postgresql-server-dev-${PG}
     debhelper fakeroot
     libtap-parser-sourcehandler-pgtap-perl
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes for the PostgreSQL table version extension are documented
 in this file.
 
 ## [1.7.1dev] - YYYY-MM-DD
+### Fixed
+- Upgrade of existing revision triggers to skip empty updates (#192)
 
 ## [1.7.0] - 2019-07-25
 ### Added


### PR DESCRIPTION
This is to effectively get the new feature of skipping empty updates
Closes #192 for 1.7 branch

Includes CHANGELOG entry