### PR TITLE
fix: Expand wildcard in right order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,9 @@ SQLSCRIPTS = \
 	$(SQLSCRIPTS_built)
 
 DOCS         = doc/table_version.md
-TESTS        = $(wildcard test/sql/*.sql)
+TESTS        = \
+	test/sql/upgrade-pre.sql \
+	test/sql/upgrade-post.sql
 
 #
 # Uncomment the MODULES line if you are adding C files


### PR DESCRIPTION
The original wildcard was returning the "post" script *before* the "pre"
script, which might've caused some issues.