### PR TITLE
refactor: Remove redundant flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ $(EXTENSION).control: $(EXTENSION).control.in
 # This is phony because it depends on env variables
 .PHONY: test/sql/preparedb
 test/sql/preparedb: test/sql/preparedb.in
-	./create-prepare-db-sql.bash "$(PREPAREDB_UPGRADE)" "$(PREPAREDB_UPGRADE_FROM)" "$(PREPAREDB_NOEXTENSION)" "$(EXTVERSION)" < $< > $@
+	./create-prepare-db-sql.bash "$(PREPAREDB_UPGRADE_FROM)" "$(PREPAREDB_NOEXTENSION)" "$(EXTVERSION)" < $< > $@
 
 installcheck: $(TESTS_built)
 	$(MAKE) test/sql/preparedb
@@ -130,9 +130,6 @@ check: $(TESTS_built) table_version-loader
 		./table_version-loader --no-extension contrib_regression
 	pg_prove --dbname=contrib_regression --verbose test/sql
 	dropdb contrib_regression
-
-installcheck-upgrade:
-	PREPAREDB_UPGRADE=1 $(MAKE) installcheck
 
 installcheck-loader: $(TESTS_built) table_version-loader
 	PREPAREDB_NOEXTENSION=1 $(MAKE) test/sql/preparedb

--- a/create-prepare-db-sql.bash
+++ b/create-prepare-db-sql.bash
@@ -3,19 +3,13 @@
 set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
 shopt -s failglob inherit_errexit
 
-upgrade="$1"
-upgrade_from="$2"
-preparedb_noextension="$3"
-extversion="$4"
+upgrade_from="$1"
+preparedb_noextension="$2"
+extversion="$3"
 
-if [[ "$upgrade" -eq 1 ]]
+if [[ -n "$upgrade_from" ]]
 then
-    if [[ -n "$upgrade_from" ]]
-    then
-        upgrade_from="version '${upgrade_from}'"
-    fi
-
-    sed --expression='s/^--UPGRADE-- //' --expression="s/@@FROM_VERSION@@/${upgrade_from-}/"
+    sed --expression='s/^--UPGRADE-- //' --expression="s/@@FROM_VERSION@@/version '${upgrade_from}'/"
 elif [[ "$preparedb_noextension" -eq 1 ]]
 then
     grep --invert-match table_version

--- a/test/ci/upgrade.bash
+++ b/test/ci/upgrade.bash
@@ -7,4 +7,4 @@ script_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 make install
 # shellcheck disable=SC2154
-make PREPAREDB_UPGRADE_FROM="$installed_package_version" installcheck-upgrade
+make PREPAREDB_UPGRADE_FROM="$installed_package_version" installcheck


### PR DESCRIPTION
`PREPAREDB_UPGRADE_FROM` is non-empty whenever `PREPAREDB_UPGRADE` is
set, so there's no need for the latter.

Blocked by repo-modifying tests.