### PR TITLE
refactor: Move safety pragmas to executables

### DIFF
--- a/test/ci/install-from-source.bash
+++ b/test/ci/install-from-source.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
+shopt -s failglob inherit_errexit
+
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # shellcheck source=test/ci/setup-postgresql.bash

--- a/test/ci/setup-postgresql.bash
+++ b/test/ci/setup-postgresql.bash
@@ -1,6 +1,3 @@
-set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
-shopt -s failglob inherit_errexit
-
 postgresql_version="$1"
 
 export DEBIAN_FRONTEND=noninteractive

--- a/test/ci/upgrade-using-loader-without-extension-support.bash
+++ b/test/ci/upgrade-using-loader-without-extension-support.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
+shopt -s failglob inherit_errexit
+
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # shellcheck source=test/ci/install-latest.bash

--- a/test/ci/upgrade-using-loader.bash
+++ b/test/ci/upgrade-using-loader.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
+shopt -s failglob inherit_errexit
+
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # shellcheck source=test/ci/install-latest.bash

--- a/test/ci/upgrade.bash
+++ b/test/ci/upgrade.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit -o noclobber -o nounset -o pipefail -o xtrace
+shopt -s failglob inherit_errexit
+
 script_dir="$(dirname "${BASH_SOURCE[0]}")"
 
 # shellcheck source=test/ci/install-latest.bash


### PR DESCRIPTION
Puts them right at the start of execution, and makes sure they don't rely
on sub-scripts.