### PR TITLE
feat: Run packaging in series to avoid issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,6 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         distro: [bionic, focal]
+      max-parallel: 1
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This is due to an issue where debian packaging script is creating
a commit on the branch during the pipeline run