### PR TITLE
fix: Use specific action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
           ./test/ci/package-upgrade.bash ${{ matrix.pg }}
 
       - name: Archive generated packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: PostgreSQL ${{ matrix.pg }} packages for Ubuntu ${{ matrix.release }}
           path: 'build-area/*.deb'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Install Nix
         uses: cachix/install-nix-action@v17
@@ -37,7 +37,7 @@ jobs:
         release: [bionic, focal]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Build Docker container
         run: docker build --build-arg=RELEASE=${{ matrix.release }} --tag=tester .
@@ -56,7 +56,7 @@ jobs:
           - release: bionic
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 
@@ -92,7 +92,7 @@ jobs:
           - release: bionic
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Build Docker container
         run: docker build --build-arg=RELEASE=${{ matrix.release }} --tag=tester .
@@ -112,7 +112,7 @@ jobs:
           - release: bionic
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Build Docker container
         run: docker build --build-arg=RELEASE=${{ matrix.release }} --tag=tester .
@@ -133,7 +133,7 @@ jobs:
           - release: bionic
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: Build Docker container
         run: docker build --build-arg=RELEASE=${{ matrix.release }} --tag=tester .
@@ -153,7 +153,7 @@ jobs:
         release: [bionic, focal]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 
@@ -189,7 +189,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Avoids quietly using whichever version is the latest starting with the specified version number, which could break at any time.

<!-- Release checklist. Uncomment this section if relevant.
## Checklist

- [ ] Update local tags using `git fetch --tags`.
- [ ] Check `git tag` for the latest released version.
- [ ] Depending on whether this is a major (X+1.0.0), minor (X.Y+1.0), or patch (X.Y.Z+1) release:
   - If this is a major or minor release, create a `release-X.Y` branch.
   - If this is a patch release, check out the existing `release-X.Y` branch.
- [ ] Add a change log entry to `CHANGELOG.md`.
- [ ] Look for anywhere there is a list of version numbers, such as the `Makefile`, test files, or others. In all those places, add your new version.
- [ ] Finish any other changes on this branch, such as merging in origin/master.
- [ ] Push the branch.
- [ ] Create a pull request for the branch.
- [ ] Wait for the pull request to build.
- [ ] Tag the final commit on the branch with `X.Y.Z`, for example, `1.10.2`.
- [ ] `git push origin TAG` with the tag created above.
- [ ] Wait for the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=).
- [ ] Manually promote the package repository to the "prod" repository.
- [ ] Wait for the pull request to build with the Debian packaging changelog commit and merge it.
- [ ] Bump the Makefile version to the next patch.
-->

<!-- External issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->
