### PR TITLE
fix: Remove workflow schedule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ on:
       - 'debian/*'
   pull_request:
     types: [opened, reopened, synchronize]
-  schedule:
-    - cron: '0 12 * * 0'
 
 jobs:
   lint:


### PR DESCRIPTION
GitHub unfortunately disables workflows with a schedule on any repo without activity for 60 days. This disabling is silent and invisible, only showing up as a slightly different icon next to the job on the Actions page. Clicking that icon will prompt whether you want to re-enable it. But at that point the damage is already done, in shape of a lot of fiddling to figure out what went wrong, and having to re-push PRs with different contents to actually trigger the now active workflow.

There's been no response from GitHub about this issue yet <https://github.com/orgs/community/discussions/32197>.

This is part of fixing
<https://github.com/linz/ds-infra-team/issues/927>.

<!-- Release checklist. Uncomment this section if relevant.
## Checklist

- [ ] Update local tags using `git fetch --tags`.
- [ ] Check `git tag` for the latest released version.
- [ ] Depending on whether this is a major (X+1.0.0), minor (X.Y+1.0), or patch (X.Y.Z+1) release:
   - If this is a major or minor release, create a `release-X.Y` branch.
   - If this is a patch release, check out the existing `release-X.Y` branch.
- [ ] Add a change log entry to `CHANGELOG.md`.
- [ ] Look for anywhere there is a list of version numbers, such as the `Makefile`, test files, or others. In all those places, add your new version.
- [ ] Finish any other changes on this branch, such as merging in origin/master.
- [ ] Push the branch.
- [ ] Create a pull request for the branch.
- [ ] Wait for the pull request to build.
- [ ] Tag the final commit on the branch with `X.Y.Z`, for example, `1.10.2`.
- [ ] `git push origin TAG` with the tag created above.
- [ ] Wait for the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=).
- [ ] Manually promote the package repository to the "prod" repository.
- [ ] Wait for the pull request to build with the Debian packaging changelog commit and merge it.
- [ ] Bump the Makefile version to the next patch.
-->

<!-- External issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->
