### PR TITLE
fix: Enable manual triggering

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 - [ ] Wait for the pull request to build.
 - [ ] Tag the final commit on the branch with `X.Y.Z`, for example, `1.10.2`.
 - [ ] `git push origin TAG` with the tag created above.
-- [ ] Wait for the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=).
+- [ ] Wait for the [tag job](https://github.com/linz/postgresql-tableversion/actions?query=branch%3AX.Y.Z) to finish and the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=) (replace `X.Y.Z` with the tag in the links).
 - [ ] Manually promote the package repository to the "prod" repository.
 - [ ] Manually trigger the PR pipeline to work around a [GitHub limitation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
 - [ ] Bump the Makefile version to the next patch.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] `git push origin TAG` with the tag created above.
 - [ ] Wait for the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=).
 - [ ] Manually promote the package repository to the "prod" repository.
-- [ ] Wait for the pull request to build with the Debian packaging changelog commit and merge it.
+- [ ] Manually trigger the PR pipeline to work around a [GitHub limitation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
 - [ ] Bump the Makefile version to the next patch.
 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 - [ ] Wait for the [tag job](https://github.com/linz/postgresql-tableversion/actions?query=branch%3AX.Y.Z) to finish and the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=) (replace `X.Y.Z` with the tag in the links).
 - [ ] Manually promote the package repository to the "prod" repository.
 - [ ] Manually trigger the PR pipeline to work around a [GitHub limitation](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)
-- [ ] Bump the Makefile version to the next patch.
+- [ ] Wait for the pull request to build and merge it.
 -->
 
 <!-- External issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
               REPO=dev
             fi
           fi
-          echo "REPO=$REPO" | tee -a $GITHUB_ENV
+          echo "REPO=$REPO" | tee --append $GITHUB_ENV
 
       - name: Build and release package
         uses: linz/linz-software-repository@v15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,11 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - master
-    tags-ignore:
-      - 'debian/*'
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - 'debian/*'
   pull_request:
     types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
<!-- Release checklist. Uncomment this section if relevant.
## Checklist

- [ ] Update local tags using `git fetch --tags`.
- [ ] Check `git tag` for the latest released version.
- [ ] Depending on whether this is a major (X+1.0.0), minor (X.Y+1.0), or patch (X.Y.Z+1) release:
   - If this is a major or minor release, create a `release-X.Y` branch.
   - If this is a patch release, check out the existing `release-X.Y` branch.
- [ ] Add a change log entry to `CHANGELOG.md`.
- [ ] Look for anywhere there is a list of version numbers, such as the `Makefile`, test files, or others. In all those places, add your new version.
- [ ] Finish any other changes on this branch, such as merging in origin/master.
- [ ] Push the branch.
- [ ] Create a pull request for the branch.
- [ ] Wait for the pull request to build.
- [ ] Tag the final commit on the branch with `X.Y.Z`, for example, `1.10.2`.
- [ ] `git push origin TAG` with the tag created above.
- [ ] Wait for the [tag job](https://github.com/linz/postgresql-tableversion/actions?query=branch%3AX.Y.Z) to finish and the package to appear in the [test repository](https://packagecloud.io/app/linz/test/search?q=tableversion_X.Y.Z&filter=all&filter=all&dist=) (replace `X.Y.Z` with the tag in the links).
- [ ] Manually promote the package repository to the "prod" repository.
- [ ] Wait for the pull request to build with the Debian packaging changelog commit and merge it.
- [ ] Bump the Makefile version to the next patch.
-->

<!-- External issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->
